### PR TITLE
Migrate the API to MuData

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,15 @@ model = CustOMICS(
     train_params=train_params,
     device=device,
 )
-model.fit(
-    omics_train=omics_train,
-    clinical_df=clinical_df,
+# prepare inputs
+prepare_input(
+    mdata=mdata,
     label="PAM50",       # classification target column
     event="OS",          # survival event column (0/1)
     surv_time="OS.time", # survival time column
+)
+model.fit(
+    mdata=mdata,
     omics_val=omics_val, # optional validation set
     batch_size=32,
     n_epochs=30,
@@ -88,20 +91,18 @@ model.fit(
 # --- 4. Evaluate ---
 # Classification metrics (Accuracy, F1, AUC, …)
 metrics = model.evaluate(
-    omics_test, clinical_df,
-    label="PAM50", event="OS", surv_time="OS.time",
+    mdata,
     task="classification",
 )
 # Survival concordance index
 ci = model.evaluate(
-    omics_test, clinical_df,
-    label="PAM50", event="OS", surv_time="OS.time",
+    mdata,
     task="survival",
 )
 
 # --- 5. Visualise & explain ---
 model.plot_loss()
-model.plot_representation(omics_train, clinical_df, label="PAM50",
+model.plot_representation(mdata, label="PAM50",
                           filename="latent_space", title="t-SNE of latent space")
 model.stratify(omics_train, clinical_df, event="OS", surv_time="OS.time")
 model.explain(sample_ids, omics_train, clinical_df,

--- a/customics/__init__.py
+++ b/customics/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 from ._logging import configure_logger
 from . import datasets, metrics
-from .utils import get_common_samples, get_sub_omics_df, toy_dataset
+from .utils import get_common_samples, get_sub_omics_df, toy_dataset, prepare_input
 from .model import CustOMICS
 
 __version__ = importlib.metadata.version("customics")

--- a/customics/_constants.py
+++ b/customics/_constants.py
@@ -1,0 +1,4 @@
+class Keys:
+    LABEL: str = "customics_label"
+    EVENT: str = "customics_event"
+    SURV_TIME: str = "customics_surv_time"

--- a/customics/datasets/multi_omics_dataset.py
+++ b/customics/datasets/multi_omics_dataset.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import torch
+from mudata import MuData
 from torch.utils.data import Dataset
 
 
@@ -14,8 +15,8 @@ class MultiOmicsDataset(Dataset):
 
     Parameters
     ----------
-    omics_df : dict of str → pd.DataFrame
-        Multi-omics data.  Each DataFrame must be indexed by sample ID.
+    mdata : MuData
+            Multi-omics object.
     clinical_df : pd.DataFrame
         Clinical metadata indexed by sample ID.
     lt_samples : list of str
@@ -37,14 +38,14 @@ class MultiOmicsDataset(Dataset):
 
     def __init__(
         self,
-        omics_df: dict[str, pd.DataFrame],
+        mdata: MuData,
         clinical_df: pd.DataFrame,
         lt_samples: list[str],
         label: str | None,
         event: str,
         surv_time: str,
     ) -> None:
-        self.omics_df = omics_df
+        self.mdata = mdata
         self.clinical_df = clinical_df
         self.lt_samples = lt_samples
         self.label = label
@@ -56,7 +57,9 @@ class MultiOmicsDataset(Dataset):
 
     def __getitem__(self, index: int) -> tuple[list[torch.Tensor], int, int, int]:
         sample = self.lt_samples[index]
-        omics_data = [torch.tensor(df.loc[sample, :].values.astype(np.float32)) for df in self.omics_df.values()]
+        omics_data = [
+            torch.tensor(adata.to_df().loc[sample, :].values.astype(np.float32)) for adata in self.mdata.mod.values()
+        ]
         lbl = self.clinical_df.loc[sample, self.label] if self.label else 0
         os_time = int(self.clinical_df.loc[sample, self.surv_time])
         os_event = int(self.clinical_df.loc[sample, self.event])

--- a/customics/model.py
+++ b/customics/model.py
@@ -13,6 +13,7 @@ from sklearn.preprocessing import LabelEncoder, OneHotEncoder
 from torch.optim import Adam
 from torch.utils.data import DataLoader
 
+from ._constants import Keys
 from .datasets import MultiOmicsDataset
 from .exceptions import ConfigurationError, DataValidationError, ModelNotFittedError
 from .loss import CoxLoss, classification_loss
@@ -399,16 +400,12 @@ class CustOMICS(nn.Module):
         DataValidationError
             If required columns are missing or samples don't overlap.
         """
-        # self._validate_fit_inputs(omics_train, clinical_df, label, event, surv_time)
 
-        required_keys = ("customics_label", "customics_event", "customics_surv_time")
-        if not all(key in mdata.uns for key in required_keys):
-            raise DataValidationError(
-                "Clinical targets are not registered in mdata.uns. Please run `customics.prepare_input` first."
-            )
-        label = mdata.uns["customics_label"]
-        event = mdata.uns["customics_event"]
-        surv_time = mdata.uns["customics_surv_time"]
+        self._validate_fit_inputs(mdata, [Keys.LABEL, Keys.EVENT, Keys.SURV_TIME])
+
+        label = mdata.uns[Keys.LABEL]
+        event = mdata.uns[Keys.EVENT]
+        surv_time = mdata.uns[Keys.SURV_TIME]
 
         encoded_clinical = mdata.obs.copy()
 
@@ -463,23 +460,20 @@ class CustOMICS(nn.Module):
         self._is_fitted = True
         return self
 
-    # def _validate_fit_inputs(
-    #     self,
-    #     omics_train: dict[str, pd.DataFrame],
-    #     clinical_df: pd.DataFrame,
-    #     label: str,
-    #     event: str,
-    #     surv_time: str,
-    # ) -> None:
-    #     for col in (label, event, surv_time):
-    #         if col not in clinical_df.columns:
-    #             raise DataValidationError(
-    #                 f"Column '{col}' not found in clinical_df. Available: {list(clinical_df.columns)}."
-    #             )
-    #     for source, df in omics_train.items():
-    #         overlap = set(df.index) & set(clinical_df.index)
-    #         if not overlap:
-    #             raise DataValidationError(f"Source '{source}' shares no sample IDs with clinical_df.")
+    def _validate_fit_inputs(
+        self,
+        mdata: MuData,
+        clinical_params: list,
+    ) -> None:
+        if not all(key in mdata.uns for key in clinical_params):
+            raise DataValidationError(
+                "Clinical parameters are not registered in mdata.uns. Please run `customics.prepare_input` first."
+            )
+
+        for source, adata in mdata.mod.items():
+            overlap = set(adata.obs_names) & set(mdata.obs_names)
+            if not overlap:
+                raise DataValidationError(f"Source '{source}' shares no sample IDs with clinical_data.")
 
     def _compute_baseline(
         self,

--- a/customics/model.py
+++ b/customics/model.py
@@ -707,8 +707,7 @@ class CustOMICS(nn.Module):
     def explain(
         self,
         sample_id: list[str],
-        omics_df: dict[str, pd.DataFrame],
-        clinical_df: pd.DataFrame,
+        mdata: MuData,
         source: str,
         subtype: str,
         label: str = "PAM50",
@@ -724,10 +723,8 @@ class CustOMICS(nn.Module):
         ----------
         sample_id:
             Sample IDs to use as the SHAP background and foreground sets.
-        omics_df:
-            Multi-omics data.
-        clinical_df : pd.DataFrame
-            Clinical metadata.
+        mdata : MuData
+            Multi-omics object whose ``obs`` holds the clinical metadata.
         source:
             Omics source key to explain.
         subtype:
@@ -756,9 +753,9 @@ class CustOMICS(nn.Module):
         )
 
         self._require_fitted()
-        expr_df = omics_df[source]
+        expr_df = mdata[source].to_df()
         sample_id = list(set(sample_id) & set(expr_df.index))
-        phenotype = processPhenotypeDataForSamples(clinical_df, sample_id, self.label_encoder)
+        phenotype = processPhenotypeDataForSamples(mdata.obs, sample_id, self.label_encoder)
         condition = phenotype[label] == subtype
 
         expr_df = expr_df.loc[sample_id, :]

--- a/customics/model.py
+++ b/customics/model.py
@@ -498,14 +498,14 @@ class CustOMICS(nn.Module):
 
     def get_latent_representation(
         self,
-        omics_df: dict[str, pd.DataFrame],
+        mdata: MuData,
     ) -> np.ndarray:
         """Compute the integrated central latent representation.
 
         Parameters
         ----------
-        omics_df:
-            Omics data for all sources (same keys as used in `fit`).
+        mdata : MuData
+            Multi-omics object with all sources (same keys as used in `fit`).
 
         Returns
         -------
@@ -519,18 +519,18 @@ class CustOMICS(nn.Module):
         """
         self._require_fitted()
         self._set_eval_mode()
-        x = [torch.tensor(omics_df[s].values, dtype=torch.float32).to(self.device) for s in self.source_names]
+        x = [torch.tensor(mdata[mod].to_df().values, dtype=torch.float32).to(self.device) for mod in self.source_names]
         with torch.no_grad():
             z = self._get_central_representation(x)
         return z.cpu().numpy()
 
-    def predict(self, omics_df: dict[str, pd.DataFrame]) -> np.ndarray:
+    def predict(self, mdata: MuData) -> np.ndarray:
         """Predict class labels.
 
         Parameters
         ----------
-        omics_df : dict
-            Omics data matching the sources used in `fit`.
+        mdata : MuData
+            Multi-omics object matching the sources used in `fit`.
 
         Returns
         -------
@@ -544,18 +544,18 @@ class CustOMICS(nn.Module):
         """
         self._require_fitted()
         self._set_eval_mode()
-        z = torch.tensor(self.get_latent_representation(omics_df), dtype=torch.float32).to(self.device)
+        z = torch.tensor(self.get_latent_representation(mdata), dtype=torch.float32).to(self.device)
         with torch.no_grad():
             logits = self.classifier(z)
         return torch.argmax(logits, dim=1).cpu().numpy()
 
-    def predict_survival(self, omics_df: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+    def predict_survival(self, mdata: MuData) -> dict[str, pd.DataFrame]:
         """Compute patient-level estimated survival functions.
 
         Parameters
         ----------
-        omics_df:
-            Omics data matching the sources used in `fit`.
+        mdata : MuData
+            Multi-omics object matching the sources used in `fit`.
 
         Returns
         -------
@@ -568,8 +568,8 @@ class CustOMICS(nn.Module):
             If called before `fit()`.
         """
         self._require_fitted()
-        lt_samples = get_common_samples(list(omics_df.values()))
-        z = torch.tensor(self.get_latent_representation(omics_df), dtype=torch.float32).to(self.device)
+        lt_samples = get_common_samples(list(mdata.mod.values()))
+        z = torch.tensor(self.get_latent_representation(mdata), dtype=torch.float32).to(self.device)
         self._set_eval_mode()
         with torch.no_grad():
             risk_scores = self.survival_predictor(z).cpu().numpy()

--- a/customics/model.py
+++ b/customics/model.py
@@ -8,6 +8,7 @@ import pandas as pd
 import torch
 import torch.nn as nn
 from lifelines import KaplanMeierFitter
+from mudata import MuData
 from sklearn.preprocessing import LabelEncoder, OneHotEncoder
 from torch.optim import Adam
 from torch.utils.data import DataLoader
@@ -367,12 +368,8 @@ class CustOMICS(nn.Module):
 
     def fit(
         self,
-        omics_train: dict[str, pd.DataFrame],
-        clinical_df: pd.DataFrame,
-        label: str,
-        event: str,
-        surv_time: str,
-        omics_val: dict[str, pd.DataFrame] | None = None,
+        mdata: MuData,
+        omics_val: MuData | None = None,
         batch_size: int = 32,
         n_epochs: int = 30,
         verbose: bool = False,
@@ -381,16 +378,8 @@ class CustOMICS(nn.Module):
 
         Parameters
         ----------
-        omics_train:
-            Training omics data.  Each DataFrame must be indexed by sample ID.
-        clinical_df:
-            Clinical metadata indexed by sample ID.
-        label:
-            Column in `clinical_df` containing class labels.
-        event:
-            Column in `clinical_df` containing the event indicator (0/1).
-        surv_time:
-            Column in `clinical_df` containing survival time.
+        mdata : MuData
+            Multi-omics object whose ``obs`` holds the clinical annotations.
         omics_val:
             Validation omics data; same format as `omics_train`.
         batch_size:
@@ -410,9 +399,19 @@ class CustOMICS(nn.Module):
         DataValidationError
             If required columns are missing or samples don't overlap.
         """
-        self._validate_fit_inputs(omics_train, clinical_df, label, event, surv_time)
+        # self._validate_fit_inputs(omics_train, clinical_df, label, event, surv_time)
 
-        encoded_clinical = clinical_df.copy()
+        required_keys = ("customics_label", "customics_event", "customics_surv_time")
+        if not all(key in mdata.uns for key in required_keys):
+            raise DataValidationError(
+                "Clinical targets are not registered in mdata.uns. Please run `customics.prepare_input` first."
+            )
+        label = mdata.uns["customics_label"]
+        event = mdata.uns["customics_event"]
+        surv_time = mdata.uns["customics_surv_time"]
+
+        encoded_clinical = mdata.obs.copy()
+
         self.label_encoder = LabelEncoder().fit(encoded_clinical[label].values)
         encoded_clinical[label] = self.label_encoder.transform(encoded_clinical[label].values)
         # Fit OHE on integer-encoded labels so it can transform integer y_true at eval time
@@ -420,10 +419,10 @@ class CustOMICS(nn.Module):
 
         loader_kw: dict = {"num_workers": 2, "pin_memory": True} if self.device.type == "cuda" else {}
 
-        lt_train = get_common_samples([*list(omics_train.values()), clinical_df])
-        self.baseline = self._compute_baseline(clinical_df, lt_train, event, surv_time)
+        lt_train = get_common_samples([*list(mdata.mod.values()), mdata])
+        self.baseline = self._compute_baseline(mdata.obs, lt_train, event, surv_time)
         train_loader = DataLoader(
-            MultiOmicsDataset(omics_train, encoded_clinical, lt_train, label, event, surv_time),
+            MultiOmicsDataset(mdata, encoded_clinical, lt_train, label, event, surv_time),
             batch_size=batch_size,
             shuffle=True,
             **loader_kw,
@@ -431,7 +430,7 @@ class CustOMICS(nn.Module):
 
         val_loader: DataLoader | None = None
         if omics_val is not None:
-            lt_val = get_common_samples([*list(omics_val.values()), clinical_df])
+            lt_val = get_common_samples([*list(mdata.mod.values()), mdata])
             val_loader = DataLoader(
                 MultiOmicsDataset(omics_val, encoded_clinical, lt_val, label, event, surv_time),
                 batch_size=batch_size,
@@ -462,23 +461,23 @@ class CustOMICS(nn.Module):
         self._is_fitted = True
         return self
 
-    def _validate_fit_inputs(
-        self,
-        omics_train: dict[str, pd.DataFrame],
-        clinical_df: pd.DataFrame,
-        label: str,
-        event: str,
-        surv_time: str,
-    ) -> None:
-        for col in (label, event, surv_time):
-            if col not in clinical_df.columns:
-                raise DataValidationError(
-                    f"Column '{col}' not found in clinical_df. Available: {list(clinical_df.columns)}."
-                )
-        for source, df in omics_train.items():
-            overlap = set(df.index) & set(clinical_df.index)
-            if not overlap:
-                raise DataValidationError(f"Source '{source}' shares no sample IDs with clinical_df.")
+    # def _validate_fit_inputs(
+    #     self,
+    #     omics_train: dict[str, pd.DataFrame],
+    #     clinical_df: pd.DataFrame,
+    #     label: str,
+    #     event: str,
+    #     surv_time: str,
+    # ) -> None:
+    #     for col in (label, event, surv_time):
+    #         if col not in clinical_df.columns:
+    #             raise DataValidationError(
+    #                 f"Column '{col}' not found in clinical_df. Available: {list(clinical_df.columns)}."
+    #             )
+    #     for source, df in omics_train.items():
+    #         overlap = set(df.index) & set(clinical_df.index)
+    #         if not overlap:
+    #             raise DataValidationError(f"Source '{source}' shares no sample IDs with clinical_df.")
 
     def _compute_baseline(
         self,
@@ -603,11 +602,7 @@ class CustOMICS(nn.Module):
 
     def evaluate(
         self,
-        omics_test: dict[str, pd.DataFrame],
-        clinical_df: pd.DataFrame,
-        label: str,
-        event: str,
-        surv_time: str,
+        mdata: MuData,
         task: str,
         batch_size: int = 32,
         plot_roc: bool = False,
@@ -616,16 +611,8 @@ class CustOMICS(nn.Module):
 
         Parameters
         ----------
-        omics_test:
-            Test omics data.
-        clinical_df:
-            Clinical metadata.
-        label:
-            Class-label column.
-        event:
-            Event-indicator column.
-        surv_time:
-            Survival-time column.
+        mdata : MuData
+            Multi-omics object whose ``obs`` holds the clinical annotations.
         task:
             `'classification'` or `'survival'`.
         batch_size:
@@ -652,13 +639,17 @@ class CustOMICS(nn.Module):
         if task not in ("classification", "survival"):
             raise ValueError(f"task must be 'classification' or 'survival', got '{task}'.")
 
-        encoded_clinical = clinical_df.copy()
+        label = mdata.uns["customics_label"]
+        event = mdata.uns["customics_event"]
+        surv_time = mdata.uns["customics_surv_time"]
+
+        encoded_clinical = mdata.obs.copy()
         encoded_clinical[label] = self.label_encoder.transform(encoded_clinical[label].values)
 
         loader_kw: dict = {"num_workers": 2, "pin_memory": True} if self.device.type == "cuda" else {}
-        lt_samples = get_common_samples([*list(omics_test.values()), clinical_df])
+        lt_samples = get_common_samples([*list(mdata.mod.values()), mdata])
         test_loader = DataLoader(
-            MultiOmicsDataset(omics_test, encoded_clinical, lt_samples, label, event, surv_time),
+            MultiOmicsDataset(mdata, encoded_clinical, lt_samples, label, event, surv_time),
             batch_size=batch_size,
             shuffle=False,
             **loader_kw,
@@ -703,7 +694,7 @@ class CustOMICS(nn.Module):
                 y_pred_proba=y_proba,
                 filename="test",
                 n_classes=self.num_classes,
-                var_names=np.unique(clinical_df[label].values.tolist()).tolist(),
+                var_names=np.unique(mdata.obs[label].values.tolist()).tolist(),
             )
         return multi_classification_evaluation(y_true, y_pred, y_proba, ohe=self.one_hot_encoder)
 

--- a/customics/model.py
+++ b/customics/model.py
@@ -430,9 +430,11 @@ class CustOMICS(nn.Module):
 
         val_loader: DataLoader | None = None
         if omics_val is not None:
-            lt_val = get_common_samples([*list(mdata.mod.values()), mdata])
+            lt_val = get_common_samples([*list(omics_val.mod.values()), omics_val])
+            val_clinical = omics_val.obs.copy()
+            val_clinical[label] = self.label_encoder.transform(val_clinical[label].values)
             val_loader = DataLoader(
-                MultiOmicsDataset(omics_val, encoded_clinical, lt_val, label, event, surv_time),
+                MultiOmicsDataset(omics_val, val_clinical, lt_val, label, event, surv_time),
                 batch_size=batch_size,
                 shuffle=False,
                 **loader_kw,

--- a/customics/utils.py
+++ b/customics/utils.py
@@ -20,7 +20,7 @@ sns.set_context("notebook", font_scale=1.5, rc={"lines.linewidth": 2.5})
 # ---------------------------------------------------------------------------
 
 
-def toy_dataset() -> tuple[dict[str, pd.DataFrame], pd.DataFrame]:
+def toy_dataset() -> MuData:
     """Load toy multi-omics dataset from GitHub.
 
     Returns
@@ -43,7 +43,15 @@ def toy_dataset() -> tuple[dict[str, pd.DataFrame], pd.DataFrame]:
     clinical_df["OS"] = rng.integers(0, 2, size=len(clinical_df))  # 0 = censored, 1 = event
     clinical_df["OS.time"] = rng.integers(200, 3000, size=len(clinical_df))  # days
 
-    return omics_df, clinical_df
+    mdata = MuData({
+        "rna": AnnData(omics_df["gene_exp"]),
+        "protein": AnnData(omics_df["protein"]),
+        "methyl": AnnData(omics_df["methyl"]),
+    })
+
+    mdata.obs = clinical_df
+
+    return mdata
 
 
 def prepare_input(mdata: MuData, label: str, event: str, surv_time: str) -> None:

--- a/customics/utils.py
+++ b/customics/utils.py
@@ -25,9 +25,9 @@ def toy_dataset() -> MuData:
 
     Returns
     -------
-    tuple of (dict, pd.DataFrame)
-        - dict: Multi-omics dictionary (source name → DataFrame).
-        - DataFrame: Clinical metadata with sample IDs as index.
+    MuData object:
+        - mdata.mod: Multi-omics dictionary (modality name → AnnData).
+        - mdata.obs: Clinical metadata with sample IDs as index.
     """
     PREFIX = "https://raw.githubusercontent.com/prism-oncology/customics/refs/heads/main/data"
 

--- a/customics/utils.py
+++ b/customics/utils.py
@@ -5,7 +5,11 @@ import os
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from anndata import AnnData
+from mudata import MuData
 from sklearn.model_selection import KFold, train_test_split
+
+from customics.exceptions import DataValidationError
 
 sns.set_style("darkgrid")
 sns.set_palette("muted")
@@ -42,27 +46,53 @@ def toy_dataset() -> tuple[dict[str, pd.DataFrame], pd.DataFrame]:
     return omics_df, clinical_df
 
 
+def prepare_input(mdata: MuData, label: str, event: str, surv_time: str) -> None:
+    """Validate clinical columns and register them in ``mdata.uns``.
+
+    Parameters
+    ----------
+    mdata : MuData
+        Multi-omics object whose ``obs`` holds the clinical annotations.
+    label : str
+        Name of the ``mdata.obs`` column used as the classification target.
+    event : str
+        Name of the ``mdata.obs`` column holding the survival event indicator
+        (1 = event, 0 = censored).
+    surv_time : str
+        Name of the ``mdata.obs`` column holding the survival time.
+
+    Raises
+    ------
+    DataValidationError
+        If any of the given columns is missing from ``mdata.obs``.
+    """
+    for key, column in {"label": label, "event": event, "surv_time": surv_time}.items():
+        if column not in mdata.obs:
+            raise DataValidationError(f"Column '{column}' not found in mdata.obs")
+        mdata.uns[f"customics_{key}"] = column
+
+
 # ---------------------------------------------------------------------------
 # Sample alignment
 # ---------------------------------------------------------------------------
 
 
-def get_common_samples(dfs: list[pd.DataFrame]) -> list[str]:
-    """Return sample IDs present in every DataFrame.
+def get_common_samples(adatas: list[AnnData]) -> list[str]:
+    """Return sample IDs present in every AnnData.
 
     Parameters
     ----------
-    dfs : list of pd.DataFrame
-        DataFrames whose indices are sample IDs.
+    adatas : list of AnnData
+        AnnData objects whose ``obs_names`` are sample IDs.
 
     Returns
     -------
     list of str
         Sorted list of common sample IDs.
     """
-    common = set(dfs[0].index)
-    for df in dfs[1:]:
-        common &= set(df.index)
+    common = set(adatas[0].obs_names)
+    for adata in adatas[1:]:
+        common &= set(adata.obs_names)
     return sorted(common)
 
 

--- a/customics/visualization.py
+++ b/customics/visualization.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from mudata import MuData
 from sklearn.manifold import TSNE
 
 if TYPE_CHECKING:
@@ -57,8 +58,7 @@ def plot_loss(history: list, switch_epoch: int, figsize: tuple = (10, 5), show: 
 
 def plot_representation(
     model: CustOMICS,
-    omics_df: dict[str, pd.DataFrame],
-    clinical_df: pd.DataFrame,
+    mdata: MuData,
     label: str,
     filename: str,
     title: str,
@@ -70,10 +70,8 @@ def plot_representation(
     ----------
     model : CustOMICS
         A fitted model.
-    omics_df : dict
-        Multi-omics data.
-    clinical_df : pd.DataFrame
-        Clinical metadata containing `label`.
+    mdata : MuData
+            Multi-omics object.
     label : str
         Column in `clinical_df` to use for colouring.
     filename : str
@@ -85,16 +83,15 @@ def plot_representation(
     """
     from customics.utils import get_common_samples
 
-    lt_samples = get_common_samples([*list(omics_df.values()), clinical_df])
-    z = model.get_latent_representation(omics_df)
-    labels_arr = clinical_df.loc[lt_samples, label].values
+    lt_samples = get_common_samples([*list(mdata.mod.values()), mdata.obs])
+    z = model.get_latent_representation(mdata)
+    labels_arr = mdata.obs.loc[lt_samples, label].values
     save_plot_score(filename, z, labels_arr, title, show=show)
 
 
 def plot_survival_stratification(
     model: CustOMICS,
-    omics_df: dict[str, pd.DataFrame],
-    clinical_df: pd.DataFrame,
+    mdata: MuData,
     event: str,
     surv_time: str,
     plot_title: str = "",
@@ -107,10 +104,8 @@ def plot_survival_stratification(
     ----------
     model : CustOMICS
         A fitted model.
-    omics_df : dict
-        Multi-omics data.
-    clinical_df : pd.DataFrame
-        Clinical metadata.
+    mdata : MuData
+            Multi-omics object.
     event : str
         Event indicator column.
     surv_time : str
@@ -128,8 +123,8 @@ def plot_survival_stratification(
     from customics.metrics.survival import cox_log_rank
     from customics.utils import get_common_samples
 
-    lt_samples = get_common_samples([*list(omics_df.values()), clinical_df])
-    z = model.get_latent_representation(omics_df)
+    lt_samples = get_common_samples([*list(mdata.mod.values()), mdata.obs])
+    z = model.get_latent_representation(mdata)
     hazard_pred = model.survival_predictor(torch.tensor(z, dtype=torch.float32).to(model.device)).cpu().detach().numpy()
     median_hazard = np.mean(hazard_pred)
     high = [s for s, h in zip(lt_samples, hazard_pred) if h > median_hazard]
@@ -137,13 +132,13 @@ def plot_survival_stratification(
 
     kmf_low = KaplanMeierFitter(label="low risk")
     kmf_high = KaplanMeierFitter(label="high risk")
-    kmf_low.fit(clinical_df.loc[low, surv_time], clinical_df.loc[low, event])
-    kmf_high.fit(clinical_df.loc[high, surv_time], clinical_df.loc[high, event])
+    kmf_low.fit(mdata.obs.loc[low, surv_time], mdata.obs.loc[low, event])
+    kmf_high.fit(mdata.obs.obsal_df.loc[high, surv_time], mdata.obs.loc[high, event])
 
     p_value = cox_log_rank(
         hazard_pred.reshape(-1),
-        np.array(clinical_df.loc[lt_samples, event].values, dtype=float),
-        np.array(clinical_df.loc[lt_samples, surv_time].values, dtype=float),
+        np.array(mdata.obs.loc[lt_samples, event].values, dtype=float),
+        np.array(mdata.obs.loc[lt_samples, surv_time].values, dtype=float),
     )
     kmf_low.plot()
     kmf_high.plot()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pyyaml>=6.0",
     "numba>=0.60,<0.62",
     "shap>=0.42",
+    "mudata>=0.3.8",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,11 +41,6 @@ def cnv_df(sample_ids):
 
 
 @pytest.fixture(scope="session")
-def omics_df(rna_df, cnv_df):
-    return {"rna": rna_df, "cnv": cnv_df}
-
-
-@pytest.fixture(scope="session")
 def clinical_df(sample_ids):
     rng = np.random.default_rng(44)
     classes = ["TypeA", "TypeB", "TypeC"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,15 @@ All fixtures use tiny synthetic data so tests run fast on CPU without any
 external files.
 """
 
+import mudata
 import numpy as np
 import pandas as pd
 import pytest
 import torch
+from anndata import AnnData
+from mudata import MuData
+
+mudata.set_options(pull_on_update=False)
 
 N_SAMPLES = 20
 N_FEATURES_RNA = 50
@@ -53,6 +58,13 @@ def clinical_df(sample_ids):
         },
         index=sample_ids,
     )
+
+
+@pytest.fixture(scope="session")
+def mu_data(rna_df, cnv_df, clinical_df):
+    mdata = MuData({"rna": AnnData(rna_df), "cnv": AnnData(cnv_df)})
+    mdata.obs = clinical_df
+    return mdata
 
 
 @pytest.fixture(scope="session")
@@ -119,17 +131,8 @@ def device():
 
 
 @pytest.fixture(scope="session")
-def fitted_model(
-    source_params,
-    central_params,
-    classif_params,
-    surv_params,
-    train_params,
-    device,
-    omics_df,
-    clinical_df,
-):
-    from customics import CustOMICS
+def fitted_model(source_params, central_params, classif_params, surv_params, train_params, device, mu_data):
+    from customics import CustOMICS, prepare_input
 
     model = CustOMICS(
         source_params=source_params,
@@ -139,12 +142,11 @@ def fitted_model(
         train_params=train_params,
         device=device,
     )
+
+    prepare_input(mdata=mu_data, label="label", event="OS", surv_time="OS.time")
+
     model.fit(
-        omics_train=omics_df,
-        clinical_df=clinical_df,
-        label="label",
-        event="OS",
-        surv_time="OS.time",
+        mdata=mu_data,
         n_epochs=3,
         batch_size=8,
         verbose=False,

--- a/tests/integration/test_training.py
+++ b/tests/integration/test_training.py
@@ -3,7 +3,7 @@
 import numpy as np
 import torch
 
-from customics import CustOMICS
+from customics import CustOMICS, prepare_input
 
 
 def test_full_pipeline_classification(
@@ -13,8 +13,7 @@ def test_full_pipeline_classification(
     surv_params,
     train_params,
     device,
-    omics_df,
-    clinical_df,
+    mu_data,
 ):
     """Fit a model and evaluate classification — smoke test for the full pipeline."""
     model = CustOMICS(
@@ -25,12 +24,9 @@ def test_full_pipeline_classification(
         train_params=train_params,
         device=device,
     )
+    prepare_input(mdata=mu_data, label="label", event="OS", surv_time="OS.time")
     model.fit(
-        omics_train=omics_df,
-        clinical_df=clinical_df,
-        label="label",
-        event="OS",
-        surv_time="OS.time",
+        mdata=mu_data,
         n_epochs=4,
         batch_size=8,
         verbose=False,
@@ -41,11 +37,7 @@ def test_full_pipeline_classification(
     assert all(isinstance(h[0], float) for h in model.history)
 
     metrics = model.evaluate(
-        omics_test=omics_df,
-        clinical_df=clinical_df,
-        label="label",
-        event="OS",
-        surv_time="OS.time",
+        mdata=mu_data,
         task="classification",
         batch_size=8,
     )
@@ -61,8 +53,7 @@ def test_full_pipeline_survival(
     surv_params,
     train_params,
     device,
-    omics_df,
-    clinical_df,
+    mu_data,
 ):
     """Fit a model and evaluate survival — smoke test for the full pipeline."""
     model = CustOMICS(
@@ -73,21 +64,14 @@ def test_full_pipeline_survival(
         train_params=train_params,
         device=device,
     )
+    prepare_input(mdata=mu_data, label="label", event="OS", surv_time="OS.time")
     model.fit(
-        omics_train=omics_df,
-        clinical_df=clinical_df,
-        label="label",
-        event="OS",
-        surv_time="OS.time",
+        mdata=mu_data,
         n_epochs=3,
         batch_size=8,
     )
     ci = model.evaluate(
-        omics_test=omics_df,
-        clinical_df=clinical_df,
-        label="label",
-        event="OS",
-        surv_time="OS.time",
+        mdata=mu_data,
         task="survival",
         batch_size=8,
     )
@@ -103,7 +87,7 @@ def test_state_dict_save_load(
     train_params,
     device,
     omics_df,
-    clinical_df,
+    mu_data,
     tmp_path,
 ):
     """Model weights must be fully recoverable via state_dict (verifies nn.ModuleList fix)."""
@@ -115,12 +99,9 @@ def test_state_dict_save_load(
         train_params=train_params,
         device=device,
     )
+    prepare_input(mdata=mu_data, label="label", event="OS", surv_time="OS.time")
     model.fit(
-        omics_df,
-        clinical_df,
-        label="label",
-        event="OS",
-        surv_time="OS.time",
+        mdata=mu_data,
         n_epochs=2,
         batch_size=8,
     )
@@ -156,8 +137,7 @@ def test_fit_with_validation(
     surv_params,
     train_params,
     device,
-    omics_df,
-    clinical_df,
+    mu_data,
 ):
     """When omics_val is provided, history should contain (train, val) tuples."""
     model = CustOMICS(
@@ -168,13 +148,10 @@ def test_fit_with_validation(
         train_params=train_params,
         device=device,
     )
+    prepare_input(mdata=mu_data, label="label", event="OS", surv_time="OS.time")
     model.fit(
-        omics_train=omics_df,
-        clinical_df=clinical_df,
-        label="label",
-        event="OS",
-        surv_time="OS.time",
-        omics_val=omics_df,
+        mdata=mu_data,
+        omics_val=mu_data,
         n_epochs=2,
         batch_size=8,
     )

--- a/tests/integration/test_training.py
+++ b/tests/integration/test_training.py
@@ -125,8 +125,8 @@ def test_state_dict_save_load(
     model2.one_hot_encoder = model.one_hot_encoder
     model2.baseline = model.baseline
 
-    preds1 = model.predict(omics_df)
-    preds2 = model2.predict(omics_df)
+    preds1 = model.predict(mu_data)
+    preds2 = model2.predict(mu_data)
     np.testing.assert_array_equal(preds1, preds2)
 
 

--- a/tests/integration/test_training.py
+++ b/tests/integration/test_training.py
@@ -86,7 +86,6 @@ def test_state_dict_save_load(
     surv_params,
     train_params,
     device,
-    omics_df,
     mu_data,
     tmp_path,
 ):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -6,8 +6,8 @@ from customics.datasets import MultiOmicsDataset
 
 
 class TestMultiOmicsDataset:
-    def test_len(self, omics_df, clinical_df, sample_ids):
-        ds = MultiOmicsDataset(omics_df, clinical_df, sample_ids, "label", "OS", "OS.time")
+    def test_len(self, mu_data, clinical_df, sample_ids):
+        ds = MultiOmicsDataset(mu_data, clinical_df, sample_ids, "label", "OS", "OS.time")
         assert len(ds) == len(sample_ids)
 
     def test_getitem_shapes(self, mu_data, clinical_df, sample_ids):
@@ -30,6 +30,6 @@ class TestMultiOmicsDataset:
         _, lbl, _, _ = ds[0]
         assert lbl == 0
 
-    def test_get_samples(self, omics_df, clinical_df, sample_ids):
-        ds = MultiOmicsDataset(omics_df, clinical_df, sample_ids, "label", "OS", "OS.time")
+    def test_get_samples(self, mu_data, clinical_df, sample_ids):
+        ds = MultiOmicsDataset(mu_data, clinical_df, sample_ids, "label", "OS", "OS.time")
         assert ds.get_samples() == sample_ids

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -10,8 +10,8 @@ class TestMultiOmicsDataset:
         ds = MultiOmicsDataset(omics_df, clinical_df, sample_ids, "label", "OS", "OS.time")
         assert len(ds) == len(sample_ids)
 
-    def test_getitem_shapes(self, omics_df, clinical_df, sample_ids):
-        ds = MultiOmicsDataset(omics_df, clinical_df, sample_ids, "label", "OS", "OS.time")
+    def test_getitem_shapes(self, mu_data, clinical_df, sample_ids):
+        ds = MultiOmicsDataset(mu_data, clinical_df, sample_ids, "label", "OS", "OS.time")
         omics_tensors, _, os_time, os_event = ds[0]
         assert len(omics_tensors) == 2
         assert omics_tensors[0].shape == (50,)  # rna
@@ -19,14 +19,14 @@ class TestMultiOmicsDataset:
         assert isinstance(os_time, int)
         assert isinstance(os_event, int)
 
-    def test_getitem_dtype(self, omics_df, clinical_df, sample_ids):
-        ds = MultiOmicsDataset(omics_df, clinical_df, sample_ids, "label", "OS", "OS.time")
+    def test_getitem_dtype(self, mu_data, clinical_df, sample_ids):
+        ds = MultiOmicsDataset(mu_data, clinical_df, sample_ids, "label", "OS", "OS.time")
         omics_tensors, _, _, _ = ds[0]
         for t in omics_tensors:
             assert t.dtype == torch.float32
 
-    def test_no_label(self, omics_df, clinical_df, sample_ids):
-        ds = MultiOmicsDataset(omics_df, clinical_df, sample_ids, None, "OS", "OS.time")
+    def test_no_label(self, mu_data, clinical_df, sample_ids):
+        ds = MultiOmicsDataset(mu_data, clinical_df, sample_ids, None, "OS", "OS.time")
         _, lbl, _, _ = ds[0]
         assert lbl == 0
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -207,16 +207,16 @@ class TestCustOMICSFit:
 
 
 class TestCustOMICSInference:
-    def test_get_latent_shape(self, fitted_model, omics_df):
-        z = fitted_model.get_latent_representation(omics_df)
+    def test_get_latent_shape(self, fitted_model, mu_data):
+        z = fitted_model.get_latent_representation(mu_data)
         assert z.shape[0] == 20  # N_SAMPLES
 
-    def test_predict_shape(self, fitted_model, omics_df):
-        preds = fitted_model.predict(omics_df)
+    def test_predict_shape(self, fitted_model, mu_data):
+        preds = fitted_model.predict(mu_data)
         assert preds.shape == (20,)
 
-    def test_predict_classes_valid(self, fitted_model, omics_df):
-        preds = fitted_model.predict(omics_df)
+    def test_predict_classes_valid(self, fitted_model, mu_data):
+        preds = fitted_model.predict(mu_data)
         assert preds.min() >= 0
         assert preds.max() < 3  # N_CLASSES
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -3,7 +3,7 @@
 import pytest
 import torch
 
-from customics import CustOMICS
+from customics import CustOMICS, prepare_input
 from customics.exceptions import ConfigurationError, DataValidationError, ModelNotFittedError
 
 
@@ -147,15 +147,7 @@ class TestCustOMICSInstantiation:
 
 class TestCustOMICSFit:
     def test_fit_returns_self(
-        self,
-        source_params,
-        central_params,
-        classif_params,
-        surv_params,
-        train_params,
-        device,
-        omics_df,
-        clinical_df,
+        self, source_params, central_params, classif_params, surv_params, train_params, device, mu_data
     ):
         model = CustOMICS(
             source_params,
@@ -165,27 +157,16 @@ class TestCustOMICSFit:
             train_params,
             device,
         )
+        prepare_input(mdata=mu_data, label="label", event="OS", surv_time="OS.time")
         result = model.fit(
-            omics_df,
-            clinical_df,
-            label="label",
-            event="OS",
-            surv_time="OS.time",
+            mu_data,
             n_epochs=2,
             batch_size=8,
         )
         assert result is model
 
     def test_history_populated(
-        self,
-        source_params,
-        central_params,
-        classif_params,
-        surv_params,
-        train_params,
-        device,
-        omics_df,
-        clinical_df,
+        self, source_params, central_params, classif_params, surv_params, train_params, device, mu_data
     ):
         model = CustOMICS(
             source_params,
@@ -195,12 +176,9 @@ class TestCustOMICSFit:
             train_params,
             device,
         )
+        prepare_input(mdata=mu_data, label="label", event="OS", surv_time="OS.time")
         model.fit(
-            omics_df,
-            clinical_df,
-            label="label",
-            event="OS",
-            surv_time="OS.time",
+            mu_data,
             n_epochs=3,
             batch_size=8,
         )
@@ -214,10 +192,9 @@ class TestCustOMICSFit:
         surv_params,
         train_params,
         device,
-        omics_df,
-        clinical_df,
+        mu_data,
     ):
-        model = CustOMICS(
+        CustOMICS(
             source_params,
             central_params,
             classif_params,
@@ -226,13 +203,7 @@ class TestCustOMICSFit:
             device,
         )
         with pytest.raises(DataValidationError, match="not found"):
-            model.fit(
-                omics_df,
-                clinical_df,
-                label="nonexistent",
-                event="OS",
-                surv_time="OS.time",
-            )
+            prepare_input(mdata=mu_data, label="nonexistent", event="OS", surv_time="OS.time")
 
 
 class TestCustOMICSInference:
@@ -249,13 +220,9 @@ class TestCustOMICSInference:
         assert preds.min() >= 0
         assert preds.max() < 3  # N_CLASSES
 
-    def test_evaluate_classification_returns_dict(self, fitted_model, omics_df, clinical_df):
+    def test_evaluate_classification_returns_dict(self, fitted_model, mu_data):
         result = fitted_model.evaluate(
-            omics_df,
-            clinical_df,
-            label="label",
-            event="OS",
-            surv_time="OS.time",
+            mu_data,
             task="classification",
             batch_size=8,
         )
@@ -263,26 +230,18 @@ class TestCustOMICSInference:
         assert "Accuracy" in result
         assert 0.0 <= result["Accuracy"] <= 1.0
 
-    def test_evaluate_survival_returns_float(self, fitted_model, omics_df, clinical_df):
+    def test_evaluate_survival_returns_float(self, fitted_model, mu_data):
         result = fitted_model.evaluate(
-            omics_df,
-            clinical_df,
-            label="label",
-            event="OS",
-            surv_time="OS.time",
+            mu_data,
             task="survival",
             batch_size=8,
         )
         assert isinstance(result, float)
         assert 0.0 <= result <= 1.0
 
-    def test_invalid_task_raises(self, fitted_model, omics_df, clinical_df):
+    def test_invalid_task_raises(self, fitted_model, mu_data):
         with pytest.raises(ValueError, match="task must be"):
             fitted_model.evaluate(
-                omics_df,
-                clinical_df,
-                label="label",
-                event="OS",
-                surv_time="OS.time",
+                mu_data,
                 task="regression",
             )

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -131,7 +131,7 @@ class TestCustOMICSInstantiation:
         surv_params,
         train_params,
         device,
-        omics_df,
+        mu_data,
     ):
         model = CustOMICS(
             source_params,
@@ -142,7 +142,7 @@ class TestCustOMICSInstantiation:
             device,
         )
         with pytest.raises(ModelNotFittedError):
-            model.predict(omics_df)
+            model.predict(mu_data)
 
 
 class TestCustOMICSFit:
@@ -194,7 +194,7 @@ class TestCustOMICSFit:
         device,
         mu_data,
     ):
-        CustOMICS(
+        model = CustOMICS(
             source_params,
             central_params,
             classif_params,
@@ -204,6 +204,7 @@ class TestCustOMICSFit:
         )
         with pytest.raises(DataValidationError, match="not found"):
             prepare_input(mdata=mu_data, label="nonexistent", event="OS", surv_time="OS.time")
+            model.fit(mu_data)
 
 
 class TestCustOMICSInference:


### PR DESCRIPTION
This PR migrates CustOmics from the `(dict[str, DataFrame], clinical_df)` input convention to a single [MuData](https://mudata.readthedocs.io/) object, the standard container for multi-omics data.
One object now carries every omics modality (as `AnnData` modalities in `mdata.mod`) and the clinical annotations (in `mdata.obs`), so the per-call `clinical_df` / `label` / `event` / `surv_time` arguments are gone.

## What changed

- **`fit`, `evaluate`, `predict`, `predict_survival`, `explain`, `plot_representation`** now take a
  single `mdata: MuData` argument instead of `(omics_df, clinical_df, label,
  event, surv_time)`.
- **New `customics.prepare_input(mdata, label, event, surv_time)`** validates the
  clinical columns exist in `mdata.obs` and registers them in `mdata.uns` (under
  `customics_label`, `customics_event`, `customics_surv_time`). `fit`/`evaluate`
  read the targets from there, so you specify them once.
- **`get_common_samples`** now aligns on `AnnData.obs_names` instead of DataFrame
  indices.
- **`toy_dataset()`** now returns a ready-to-use `MuData` instead of a
  `(dict, DataFrame)` tuple.
- `mudata` / `anndata` added as dependencies; tests and fixtures updated.

## New usage

```python
import torch
import customics
from customics import CustOMICS, prepare_input

# 1. Load data as a MuData object (modalities in .mod, clinical in .obs)
mdata = customics.toy_dataset()

# 2. Register the clinical targets once
prepare_input(mdata, label="cluster.id", event="OS", surv_time="OS.time")

# 3. Configure & train
device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
model = CustOMICS(
    source_params=source_params,
    central_params=central_params,
    classif_params=classif_params,
    surv_params=surv_params,
    train_params=train_params,
    device=device,
)
model.fit(mdata, n_epochs=30, batch_size=32)

# 4. Evaluate (targets are read from mdata.uns)
acc = model.evaluate(mdata, task="classification")
ci  = model.evaluate(mdata, task="survival")
```

### Todo list:

- [ ]  README and tutorial docs to be updated to the MuData API.

